### PR TITLE
Add `title` attribute to auto-TOC links (fixes #2)

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -69,7 +69,7 @@ class AutoTOC {
     }
     return `
       <li>
-        <a data-level="${item.level - this.rootLevel}" href="#${item.id}">${item.name}</a>
+        <a data-level="${item.level - this.rootLevel}" title="${item.name}" href="#${item.id}">${item.name}</a>
         ${list}
       </li>
     `;

--- a/hovercard_resolution/index.js
+++ b/hovercard_resolution/index.js
@@ -53,6 +53,9 @@ async function resolve() {
     if (doc.description) {
       doc.description = mdRender(doc.description, { skip_hovercard: true })
     }
+    if (typeof doc === "object") {
+      doc.value ??= simpleLabel;
+    }
     bundles.push(doc);
   }
 


### PR DESCRIPTION
Also added in a hovercard related change whose purpose I don't remember, but must be there for a reason.